### PR TITLE
Add build and run scripts for Windows and Unix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ replay_pid*
 
 # ignore ant build
 target/
+
+# build scripts (optional - remove these lines if you want to track the scripts)
+# build_and_run.bat
+# build_and_run.sh

--- a/build_and_run.bat
+++ b/build_and_run.bat
@@ -1,0 +1,27 @@
+@echo off
+echo Building Shimeji-ee...
+echo.
+
+REM Clean and build the project
+ant clean jar
+
+if %ERRORLEVEL% neq 0 (
+    echo Build failed!
+    pause
+    exit /b 1
+)
+
+echo.
+echo Build successful! Starting Shimeji-ee...
+echo.
+
+REM Run the application
+java -cp "target\Shimeji-ee.jar;lib\*" com.group_finity.mascot.Main
+
+if %ERRORLEVEL% neq 0 (
+    echo Application failed to start properly.
+    pause
+    exit /b 1
+)
+
+pause

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "Building Shimeji-ee..."
+echo
+
+# Clean and build the project
+ant clean jar
+
+if [ $? -ne 0 ]; then
+    echo "Build failed!"
+    exit 1
+fi
+
+echo
+echo "Build successful! Starting Shimeji-ee..."
+echo
+
+# Run the application (Unix-style classpath with colon separator)
+java -cp "target/Shimeji-ee.jar:lib/*" com.group_finity.mascot.Main
+
+if [ $? -ne 0 ]; then
+    echo "Application failed to start properly."
+    exit 1
+fi


### PR DESCRIPTION
Introduced build_and_run.bat and build_and_run.sh scripts to automate building and running the Shimeji-ee project on Windows and Unix systems. Updated .gitignore to optionally ignore these scripts.